### PR TITLE
get footprints of search results

### DIFF
--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -44,7 +44,7 @@ class SentinelAPI(object):
 
     def format_url(self, area, initial_date=None, end_date=datetime.now(), **keywords):
         """Create the URL to access the SciHub API, defining the max quantity of
-        results to 1500 items.
+        results to 15000 items.
         """
         if initial_date is None:
             initial_date = end_date - timedelta(hours=24)
@@ -59,7 +59,7 @@ class SentinelAPI(object):
         for kw in sorted(keywords.keys()):
             filters += ' AND (%s:%s)' % (kw, keywords[kw])
 
-        self.url = 'https://scihub.esa.int/dhus/search?format=json&rows=1500&q=%s%s%s' \
+        self.url = 'https://scihub.esa.int/dhus/search?format=json&rows=15000&q=%s%s%s' \
             % (ingestion_date, query_area, filters)
 
     def get_products(self):

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 from __future__ import print_function
 
-from homura import download
+import homura
+import pycurl
+import certifi
 import requests
 import json
 import geojson
@@ -147,7 +149,8 @@ class SentinelAPI(object):
                 print('%s was already downloaded.' % path)
                 return path
 
-        download(product['url'], path=path, session=self.session)
+        # download product, include certificate bundle from certifi
+        homura.download(product['url'], path=path, session=self.session, pass_through_opts={pycurl.CAINFO : certifi.where()})
         return path
 
     def download_all(self, path='.'):

--- a/setup.py
+++ b/setup.py
@@ -30,6 +30,7 @@ setup(name='sentinelsat',
           'requests',
           'click',
           'homura',
+          'certifi',
           'geojson'
       ],
       extras_require={

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='sentinelsat',
       install_requires=[
           'requests',
           'click',
-          'homura',
+          'homura>=0.1.2',
           'certifi',
           'geojson'
       ],


### PR DESCRIPTION
I added a function to create a geojson FeatureCollection containing all footprint polygons and relevant metadata of a search result. This can also be invoked from the cli with the *-f* option, creating a geojson file of the search result to get a quick overlook of the spatial distribution of the search results. This is especially useful if you are searching in larger areas (think whole countries).

*get_product_info()* now also contains the footprint coordinates in the returned dict and the test for it has been expanded.