### PR TITLE
pass any keyword argument to homura and fix CA errors

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -106,6 +106,24 @@ To download all the results of your query, use:
 
     api.download_all()
 
+The download from <https://scihub.esa.int> will fail if the server certificate 
+cannot be verified because no default CA bundle is defined, as on Windows, or
+when the CA bundle is outdated. In most cases the easiest solution is to
+install or update `certifi <https://pypi.python.org/pypi/certifi>`:
+
+.. code-block:: console
+
+    pip install -U certifi
+
+You can also override the the path setting to the PEM file of the CA bundle using
+the `pass_through_opts` keyword argument when calling `api.download()` or `api.download_all()`:
+
+.. code-block:: python
+
+    from pycurl import CAINFO
+    api.download_all(pass_through_opts={CAINFO: 'path/to/my/cacert.pem'})
+
+
 License
 =======
 

--- a/README.rst
+++ b/README.rst
@@ -77,6 +77,13 @@ If you know the id of the product you want to download, you can download it by u
 
     api.download(<product_id>)
 
+It is possible to hide the progress report, disable resume and auto_retry, and 
+pass any other keyword argument understood by the underlying homura library, e.g.:
+
+.. code-block:: python
+
+    api.download(<product_id>, show_progress=False, max_rst_retries=2)
+
 You can search products by specifying the coordinates of the area and a date interval:
 
 .. code-block:: python
@@ -109,14 +116,15 @@ To download all the results of your query, use:
 The download from https://scihub.esa.int will fail if the server certificate 
 cannot be verified because no default CA bundle is defined, as on Windows, or
 when the CA bundle is outdated. In most cases the easiest solution is to
-install or update `certifi <https://pypi.python.org/pypi/certifi>`:
+install or update `certifi <https://pypi.python.org/pypi/certifi>`_:
 
 .. code-block:: console
 
     pip install -U certifi
 
 You can also override the the path setting to the PEM file of the CA bundle using
-the pass_through_opts keyword argument when calling api.download() or api.download_all():
+the ``pass_through_opts`` keyword argument when calling ``api.download()`` or 
+``api.download_all()``:
 
 .. code-block:: python
 

--- a/README.rst
+++ b/README.rst
@@ -106,7 +106,7 @@ To download all the results of your query, use:
 
     api.download_all()
 
-The download from <https://scihub.esa.int> will fail if the server certificate 
+The download from https://scihub.esa.int will fail if the server certificate 
 cannot be verified because no default CA bundle is defined, as on Windows, or
 when the CA bundle is outdated. In most cases the easiest solution is to
 install or update `certifi <https://pypi.python.org/pypi/certifi>`:
@@ -116,7 +116,7 @@ install or update `certifi <https://pypi.python.org/pypi/certifi>`:
     pip install -U certifi
 
 You can also override the the path setting to the PEM file of the CA bundle using
-the `pass_through_opts` keyword argument when calling `api.download()` or `api.download_all()`:
+the pass_through_opts keyword argument when calling api.download() or api.download_all():
 
 .. code-block:: python
 

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -92,9 +92,10 @@ class SentinelAPI(object):
             ]
         return dict(zip(keys, values))
 
-    def download(self, id, path='.'):
+    def download(self, id, path='.', **kwargs):
         """Download a product using homura's download function. If you don't
-        pass the title of the product, it will use the id as filename.
+        pass the title of the product, it will use the id as filename. Further
+        keyword arguments are passed to homura.
         """
         product = self.get_product_info(id)
         path = join(path, product['title'] + '.zip')
@@ -107,12 +108,12 @@ class SentinelAPI(object):
                 print('%s was already downloaded.' % path)
                 return path
 
-        download(product['url'], path=path, session=self.session)
+        download(product['url'], path=path, session=self.session, **kwargs)
         return path
 
-    def download_all(self, path='.'):
+    def download_all(self, path='.', **kwargs):
         for product in self.get_products():
-            self.download(product['id'], path)
+            self.download(product['id'], path, **kwargs)
 
 
 def get_coordinates(geojson_file, feature_number=0):

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -100,9 +100,11 @@ class SentinelAPI(object):
         return dict(zip(keys, values))
 
     def download(self, id, path='.', **kwargs):
-        """Download a product using homura's download function. If you don't
-        pass the title of the product, it will use the id as filename. Further
-        keyword arguments are passed to homura.
+        """Download a product using homura's download function.
+        
+        If you don't pass the title of the product, it will use the id as 
+        filename. Further keyword arguments are passed to the 
+        homura.download() function.
         """
         product = self.get_product_info(id)
         path = join(path, product['title'] + '.zip')
@@ -120,18 +122,23 @@ class SentinelAPI(object):
         return path
 
     def download_all(self, path='.', **kwargs):
+        """Download all products using homura's download function.
+        
+        It will use the products id as filenames. Further keyword arguments 
+        are passed to the homura.download() function.
+        """
         for product in self.get_products():
             self.download(product['id'], path, **kwargs)
 
     @staticmethod
     def _fillin_cainfo(kwargs_dict):
-        """Pick the path of the PEM file containing the CA certificate.
+        """Fill in the path of the PEM file containing the CA certificate.
+        
         The priority is: 1. user provided path, 2. path to the cacert.pem 
         bundle provided by certifi (if installed), 3. let pycurl use the 
         system path where libcurl's cacert bundle is assumed to be stored, 
         as established at libcurl build time.
         """
-        
         try:
             cainfo = kwargs_dict['pass_through_opts'][CAINFO]
         except KeyError:

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup(name='sentinelsat',
       install_requires=[
           'requests',
           'click',
-          'homura'
+          'homura>=0.1.2'
       ],
       extras_require={
           'test': ['pytest'],


### PR DESCRIPTION
This makes it possible e.g. to hide the progress bar with `show_progress=False` and other options already supported in the homura version on pypi, and most importantly to close #1 by providing a mechanism to pass the CA certificate path through homura to pycurl (once shichao-an/homura#4 is addressed).