### PR TITLE
MD5 checksum testing after download

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@ sentinelsat
     :target: http://badge.fury.io/py/sentinelsat
 
 
-Utility pack to search and download Sentinel-1 imagery from `ESA SciHub <https://scihub.esa.int/>.
+Utility pack to search and download Sentinel-1 imagery from `ESA SciHub <https://scihub.esa.int/>`_.
 
 Installation
 ============
@@ -27,13 +27,13 @@ Fedora
 
 Windows
 
-The easiest way to install pycurl is to use one of the `pycurl wheels <http://www.lfd.uci.edu/~gohlke/pythonlibs/#pycurl> provided by Christoph Gohlke.
+The easiest way to install pycurl is to use one of the `pycurl wheels <http://www.lfd.uci.edu/~gohlke/pythonlibs/#pycurl>`_ provided by Christoph Gohlke.
 
 .. code-block:: console
 
     pip install pycurl.whl
 
-Alternatively if you are using `Conda <http://conda.pydata.org/docs/> you can do
+Alternatively if you are using `Conda <http://conda.pydata.org/docs/>`_ you can do
 
 .. code-block:: console
 

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -66,7 +66,7 @@ def search(user, password, geojson, start, end, download, check, footprints, pat
         size_total = 0
         for product in api.get_products():
             print('Product %s - %s' % (product['id'], product['summary']))
-            size_product = int(next(x for x in product["str"] if x["name"] == "size")["content"][:-3])
+            size_product = float(next(x for x in product["str"] if x["name"] == "size")["content"][:-3])
             size_total += size_product
         print('---')
         print('%s scenes found with a total size of %s MB' % (len(api.get_products()), size_total))

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -21,6 +21,8 @@ def cli():
     help='End date of the query in the format YYYYMMDD.')
 @click.option('--download', '-d', is_flag=True,
     help='Download all results of the query.')
+@click.option('--check', '-c', is_flag=True,
+    help='Verify the MD5 checksum and write corrupt product ids to a textfile.')
 @click.option('--footprints', '-f', is_flag=True,
     help='Create a geojson file with footprints of the query result.')
 @click.option('--path', '-p', type=click.Path(exists=True), default='.',
@@ -33,7 +35,7 @@ def cli():
     help="""Define another API URL. Default URL is
         'https://scihub.esa.int/apihub/'.
         """)
-def search(user, password, geojson, start, end, download, footprints, path, query, url):
+def search(user, password, geojson, start, end, download, check, footprints, path, query, url):
     """Search for Sentinel-1 products and, optionally, download all the results
     and/or create a geojson file with the search result footprints.
     Beyond your SciHub user and password, you must pass a geojson file
@@ -52,7 +54,13 @@ def search(user, password, geojson, start, end, download, footprints, path, quer
         with open(os.path.join(path, "search_footprints.geojson"), "w") as outfile:
             outfile.write(gj.dumps(footprints_geojson))
 
-    if download is True:
+    if download is True and check is True:
+        corrupt_scenes = api.download_all(path, check)
+        if len(corrupt_scenes) is not 0:
+            with open(os.path.join(path, "corrupt_scenes.txt"), "w") as outfile:
+                for product_id in corrupt_scenes:
+                    outfile.write("%s\n" % product_id)
+    elif download is True and check is False:
         api.download_all(path)
     else:
         size_total = 0
@@ -70,6 +78,8 @@ def search(user, password, geojson, start, end, download, footprints, path, quer
 @click.argument('productid', type=str, metavar='<productid>')
 @click.option('--path', '-p', type=click.Path(exists=True), default='.',
     help='Set the path where the files will be saved.')
+@click.option('--check', '-c', is_flag=True,
+    help='Verify the MD5 checksum and write corrupt product ids to a textfile.')
 @click.option('--url', '-u', type=str, default='https://scihub.esa.int/apihub/',
     help="""Define another API URL. Default URL is
         'https://scihub.esa.int/apihub/'.
@@ -79,4 +89,4 @@ def download(user, password, productid, path, url):
     and the id of the product you want to download.
     """
     api = SentinelAPI(user, password, url)
-    api.download(productid, path)
+    api.download(productid, path, check)

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -55,8 +55,13 @@ def search(user, password, geojson, start, end, download, footprints, path, quer
     if download is True:
         api.download_all(path)
     else:
+        size_total = 0
         for product in api.get_products():
             print('Product %s - %s' % (product['id'], product['summary']))
+            size_product = int(next(x for x in product["str"] if x["name"] == "size")["content"][:-3])
+            size_total += size_product
+        print('---')
+        print('%s scenes found with a total size of %s MB' % (len(api.get_products()), size_total))
 
 
 @cli.command()

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -84,7 +84,7 @@ def search(user, password, geojson, start, end, download, check, footprints, pat
     help="""Define another API URL. Default URL is
         'https://scihub.esa.int/apihub/'.
         """)
-def download(user, password, productid, path, url):
+def download(user, password, productid, path, check, url):
     """Download a Sentinel-1 Product. It just needs your SciHub user and password
     and the id of the product you want to download.
     """

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -69,7 +69,7 @@ def search(user, password, geojson, start, end, download, check, footprints, pat
             size_product = float(next(x for x in product["str"] if x["name"] == "size")["content"][:-3])
             size_total += size_product
         print('---')
-        print('%s scenes found with a total size of %s MB' % (len(api.get_products()), size_total))
+        print('%s scenes found with a total size of %s GB' % (len(api.get_products()), size_total))
 
 
 @cli.command()

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -135,7 +135,7 @@ class SentinelAPI(object):
 
     def get_product_info(self, id):
         """Access SciHub API to get info about a Product. Returns a dict
-        containing the id, title, size, date, footprint and download url of the
+        containing the id, title, size, md5sum, date, footprint and download url of the
         Product. The date field receives the Start ContentDate of the API.
         """
 
@@ -159,11 +159,12 @@ class SentinelAPI(object):
             [" ".join(double_coord) for double_coord in [coord.split(",") for coord in poly_coords.split(" ")]]
         )
 
-        keys = ['id', 'title', 'size', 'date', 'footprint', 'url']
+        keys = ['id', 'title', 'size', 'md5', 'date', 'footprint', 'url']
         values = [
             product_json['d']['Id'],
             product_json['d']['Name'],
             int(product_json['d']['ContentLength']),
+            product_json['d']['Checksum']['Value'],
             convert_timestamp(product_json['d']['ContentDate']['Start']),
             coord_string,
             join(self.api_url, "odata/v1/Products('%s')/$value" % id)
@@ -183,7 +184,7 @@ class SentinelAPI(object):
             try:
                 product = self.get_product_info(id)
             except ValueError:
-                print("Invalid API responses. Trying again in 3 minutes.")
+                print("Invalid API response. Trying again in 3 minutes.")
                 sleep(180)
 
         path = join(path, product['title'] + '.zip')

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -4,11 +4,12 @@ import requests_mock
 
 from datetime import datetime, date, timedelta
 from os import environ
+import hashlib
 
 from sentinelsat.sentinel import (SentinelAPI, format_date, get_coordinates,
-    convert_timestamp)
+    convert_timestamp, md5_compare)
 
-
+@pytest.mark.fast
 def test_format_date():
     assert format_date(datetime(2015, 1, 1)) == '2015-01-01T00:00:00Z'
     assert format_date(date(2015, 1, 1)) == '2015-01-01T00:00:00Z'
@@ -17,8 +18,19 @@ def test_format_date():
     assert format_date('NOW') == 'NOW'
 
 
+@pytest.mark.fast
 def test_convert_timestamp():
     assert convert_timestamp('/Date(1445588544652)/') == '2015-10-23T08:22:24Z'
+
+
+@pytest.mark.fast
+def test_md5_comparison():
+    testfile_md5 = hashlib.md5()
+    with open("tests/expected_search_footprints.geojson", "rb") as testfile:
+        testfile_md5.update(testfile.read())
+        real_md5 = testfile_md5.hexdigest()
+    assert md5_compare("tests/expected_search_footprints.geojson", real_md5) == True
+    assert md5_compare("tests/map.geojson", real_md5) == False
 
 
 @pytest.mark.scihub
@@ -63,6 +75,7 @@ def test_set_base_url():
     assert api.content.status_code == 200
 
 
+@pytest.mark.fast
 def test_get_coordinates():
     coords = '-66.2695312 -8.0592296,-66.2695312 0.7031074,' + \
         '-57.3046875 0.7031074,-57.3046875 -8.0592296,' +\

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -78,6 +78,8 @@ def test_get_product_info():
     )
 
     expected = {'id': '8df46c9e-a20c-43db-a19a-4240c2ed3b8b',
+        'size': int(143549851),
+        'md5': 'D5E4DF5C38C6E97BF7E7BD540AB21C05',
         'url': "https://scihub.esa.int/apihub/odata/v1/Products('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')/$value",
         'date': '2015-11-21T10:03:56Z',  'size': 143549851,
         'footprint': '-5.880887 -63.852531,-5.075419 -67.495872,-3.084356 -67.066071,-3.880541 -63.430576,-5.880887 -63.852531',


### PR DESCRIPTION
Verification of downloaded scenes, as proposed in #15 

The `download`, `download_all` methods and their CLI counterparts now support validation of the downloaded file with the ESA provided MD5 checksum.

- `download` of a single scene raises an error if the check fails
- `download_all` continues the download and returns a list of corrupt scenes that failed the check

The CLI has a new option `-c` which performs the test after each download and creates a text file *corrupted_scenes.txt* with the product ids of the corrupt scenes, if there are any.

Additionaly `sentinel search` now also reports the number of scenes found and their total size.