### PR TITLE
bugfixes

### DIFF
--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -58,8 +58,8 @@ def search(user, password, geojson, start, end, download, check, footprints, pat
         corrupt_scenes = api.download_all(path, check)
         if len(corrupt_scenes) is not 0:
             with open(os.path.join(path, "corrupt_scenes.txt"), "w") as outfile:
-                for product_id in corrupt_scenes:
-                    outfile.write("%s\n" % product_id)
+                for corrupt_tuple in corrupt_scenes:
+                    outfile.write("%s : %s\n" % corrupt_tuple)
     elif download is True and check is False:
         api.download_all(path)
     else:

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -63,13 +63,10 @@ def search(user, password, geojson, start, end, download, check, footprints, pat
     elif download is True and check is False:
         api.download_all(path)
     else:
-        size_total = 0
         for product in api.get_products():
             print('Product %s - %s' % (product['id'], product['summary']))
-            size_product = float(next(x for x in product["str"] if x["name"] == "size")["content"][:-3])
-            size_total += size_product
         print('---')
-        print('%s scenes found with a total size of %s GB' % (len(api.get_products()), size_total))
+        print('%s scenes found with a total size of %.2f GB' % (len(api.get_products()), api.get_products_size()))
 
 
 @cli.command()

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -15,6 +15,7 @@ import hashlib
 import xml.etree.ElementTree as ET
 from datetime import datetime, date, timedelta
 from time import sleep
+from urlparse import urljoin
 from os.path import join, exists, getsize
 from os import remove
 
@@ -49,7 +50,7 @@ class SentinelAPI(object):
     def __init__(self, user, password, api_url='https://scihub.copernicus.eu/apihub/'):
         self.session = requests.Session()
         self.session.auth = (user, password)
-        self.api_url = api_url
+        self.api_url = self._url_trail_slash(api_url)
 
     def query(self, area, initial_date=None, end_date=datetime.now(), **keywords):
         """Query the SciHub API with the coordinates of an area, a date inverval
@@ -64,6 +65,12 @@ class SentinelAPI(object):
         except requests.exceptions.RequestException as exc:
             print('Error: {}'.format(exc))
 
+    @staticmethod
+    def _url_trail_slash(api_url):
+        """Add trailing slash to the api url if it is missing"""
+        if api_url[-1] is not '/':
+            api_url += '/'
+        return api_url
 
     def format_url(self, area, initial_date=None, end_date=datetime.now(), **keywords):
         """Create the URL to access the SciHub API, defining the max quantity of

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -213,12 +213,13 @@ class SentinelAPI(object):
 
         print('Downloading %s to %s' % (id, path))
 
-        # Check if the file exists and if it is complete
-        if exists(path):
-            if getsize(path) == product['size']:
-                print('%s was already downloaded.' % path)
-                return path
-
+        # Check if the file exists and passes md5 test
+        if exists(path) and md5_compare(path, product['md5'].lower()):
+            print('%s was already downloaded.' % path)
+            return path
+        else:
+            remove(path)
+            
         download(product['url'], path=path, session=self.session, **kwargs)
 
         # Check integrity with MD5 checksum
@@ -231,15 +232,16 @@ class SentinelAPI(object):
         """Download all products using homura's download function.
 
         It will use the products id as filenames. If the checksum calculation
-        fails a list with product ids of the corrupt scenes will be returned.
-        Further keyword arguments are passed to the homura.download() function.
+        fails a list with tuples of filename and product ids of the corrupt
+        scenes will be returned. Further keyword arguments are passed to the
+        homura.download() function.
         """
         corrupt_scenes = []
         for product in self.get_products():
             try:
                 self.download(product['id'], path, checksum, **kwargs)
             except ValueError:
-                corrupt_scenes.append(product['id'])
+                corrupt_scenes.append((product['title']+'.zip', product['id']))
         return corrupt_scenes
 
     @staticmethod

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -110,6 +110,18 @@ class SentinelAPI(object):
         except ValueError:  # catch simplejson.decoder.JSONDecodeError
             raise ValueError('API response not valid. JSON decoding failed.')
 
+    def get_products_size(self):
+        """Return the total filesize in Gb of all products in the query"""
+        size_total = 0
+        for product in self.get_products():
+            size_product = next(x for x in product["str"] if x["name"] == "size")["content"]
+            size_value = float(size_product.split(" ")[0])
+            size_unit = str(size_product.split(" ")[1])
+            if size_unit == "MB":
+                size_value /= 1024
+            size_total += size_value
+        return round(size_total, 2)
+
     def get_footprints(self):
         """Return the footprints of the resulting scenes in GeoJSON format"""
         id = 0

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -15,7 +15,10 @@ import hashlib
 import xml.etree.ElementTree as ET
 from datetime import datetime, date, timedelta
 from time import sleep
-from urlparse import urljoin
+try:
+    from urlparse import urljoin
+except:
+    from urllib.parse import urljoin
 from os.path import join, exists, getsize
 from os import remove
 
@@ -219,7 +222,7 @@ class SentinelAPI(object):
             return path
         else:
             remove(path)
-            
+
         download(product['url'], path=path, session=self.session, **kwargs)
 
         # Check integrity with MD5 checksum

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -89,7 +89,7 @@ class SentinelAPI(object):
         for kw in sorted(keywords.keys()):
             filters += ' AND (%s:%s)' % (kw, keywords[kw])
 
-        self.url = join(
+        self.url = urljoin(
             self.api_url,
             'search?format=json&rows=15000&q=%s%s%s' % (ingestion_date, query_area, filters)
         )
@@ -149,7 +149,7 @@ class SentinelAPI(object):
         """
 
         product = self.session.get(
-            join(self.api_url, "odata/v1/Products('%s')/?$format=json" % id)
+            urljoin(self.api_url, "odata/v1/Products('%s')/?$format=json" % id)
         )
 
         try:
@@ -176,7 +176,7 @@ class SentinelAPI(object):
             product_json['d']['Checksum']['Value'],
             convert_timestamp(product_json['d']['ContentDate']['Start']),
             coord_string,
-            join(self.api_url, "odata/v1/Products('%s')/$value" % id)
+            urljoin(self.api_url, "odata/v1/Products('%s')/$value" % id)
         ]
         return dict(zip(keys, values))
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,3 +32,32 @@ def test_cli():
         '-q', 'producttype=GRD,polarisationmode=HH'
         ])
     assert result.exit_code == 0
+
+def test_returned_filesize():
+    runner = CliRunner()
+
+    result = runner.invoke(cli,
+        ['search',
+        environ.get('SENTINEL_USER'),
+        environ.get('SENTINEL_PASSWORD'),
+        'tests/map.geojson',
+        '--url', 'https://scihub.copernicus.eu/dhus/',
+        '-s', '20141205',
+        '-e', '20141208',
+        '-q', 'producttype=GRD'
+        ])
+    expected = "1 scenes found with a total size of 0.50 GB"
+    assert result.output.split("\n")[-2] == expected
+
+    result = runner.invoke(cli,
+        ['search',
+        environ.get('SENTINEL_USER'),
+        environ.get('SENTINEL_PASSWORD'),
+        'tests/map.geojson',
+        '--url', 'https://scihub.copernicus.eu/dhus/',
+        '-s', '20140101',
+        '-e', '20141231',
+        '-q', 'producttype=GRD'
+        ])
+    expected = "13 scenes found with a total size of 7.23 GB"
+    assert result.output.split("\n")[-2] == expected

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -93,6 +93,7 @@ def test_trail_slash_base_url():
         )
         assert api.api_url == expected
 
+
 @pytest.mark.fast
 def test_get_coordinates():
     coords = '-66.2695312 -8.0592296,-66.2695312 0.7031074,' + \

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -76,6 +76,24 @@ def test_set_base_url():
 
 
 @pytest.mark.fast
+def test_trail_slash_base_url():
+    base_urls = [
+    'https://scihub.copernicus.eu/dhus/',
+    'https://scihub.copernicus.eu/dhus'
+    ]
+
+    expected = 'https://scihub.copernicus.eu/dhus/'
+
+    for test_url in base_urls:
+        assert SentinelAPI._url_trail_slash(test_url) == expected
+        api = SentinelAPI(
+            environ.get('SENTINEL_USER'),
+            environ.get('SENTINEL_PASSWORD'),
+            test_url
+        )
+        assert api.api_url == expected
+
+@pytest.mark.fast
 def test_get_coordinates():
     coords = '-66.2695312 -8.0592296,-66.2695312 0.7031074,' + \
         '-57.3046875 0.7031074,-57.3046875 -8.0592296,' +\


### PR DESCRIPTION
Some small bugfixes:
- filesize reported by `>sentinel search` has been corrected (MB, GB)
- *corrupt_scenes.txt* now includes filenames as well as IDs of products that failed the md5 check
- md5 is used to test the validity of an already downloaded image instead of filesize
- testing provided api urls for trailing slashes