### PR TITLE
Better exceptions

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -13,7 +13,7 @@ It offers an easy to use command line interface.
   sentinel search --sentinel2 --cloud 30 user password search_polygon.geojson
 
 
-and a powerfull Python API.
+and a powerful Python API.
 
 .. code-block:: python
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 requests
 click
 homura>=0.1.2
+html2text
 geojson
 tqdm

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -5,14 +5,15 @@ import hashlib
 import sys
 import traceback
 import xml.etree.ElementTree as ET
-from datetime import datetime, date, timedelta
+from datetime import date, datetime, timedelta
 from os import remove
-from os.path import join, exists, getsize
+from os.path import exists, getsize, join
 from pycurl import CAINFO
 from time import sleep
 
 import geojson
 import homura
+import html2text
 import requests
 from tqdm import tqdm
 
@@ -25,6 +26,18 @@ try:
     import certifi
 except ImportError:
     certifi = None
+
+
+class SentinelAPIError(Exception):
+    def __init__(self, http_status=None, code=None, msg=None, response_body=None):
+        self.http_status = http_status
+        self.code = code
+        self.msg = msg
+        self.response_body = response_body
+
+    def __str__(self):
+        return '(HTTP status: {0}, code: {1}) {2}'.format(
+            self.http_status, self.code, self.msg)
 
 
 class InvalidChecksumError(Exception):
@@ -54,21 +67,26 @@ def convert_timestamp(in_date):
 
 
 def _check_scihub_response(response):
-    """Check that the response from server has status code 2xx.
-    If the response contains an API error message in JSON throw that as a ValueError. Throw HTTPError otherwise."""
+    """Check that the response from server has status code 2xx and that the response is valid JSON."""
     try:
         response.raise_for_status()
-    except requests.HTTPError:
-        msg = None
+        response.json()
+    except (requests.HTTPError, ValueError) as e:
+        msg = "API response not valid. JSON decoding failed."
+        code = None
         try:
             msg = response.json()['error']['message']['value']
+            code = response.json()['error']['code']
         except:
-            pass
-        if msg:
-            # If an error message is available then we are probably dealing with an API error
-            raise ValueError(msg)
-        else:
-            raise
+            if not response.text.rstrip().startswith('{'):
+                try:
+                    h = html2text.HTML2Text()
+                    h.ignore_images = True
+                    h.ignore_anchors = True
+                    msg = h.handle(response.text).strip()
+                except:
+                    pass
+        raise SentinelAPIError(response.status_code, code, msg, response.content)
 
 
 class SentinelAPI(object):
@@ -117,7 +135,7 @@ class SentinelAPI(object):
         """
         self.last_query = query
         self.content = requests.post(self.url, dict(q=query), auth=self.session.auth)
-        self.content.raise_for_status()
+        _check_scihub_response(self.content)
 
     @staticmethod
     def _url_trail_slash(api_url):
@@ -160,8 +178,10 @@ class SentinelAPI(object):
         except KeyError:
             print('No products found in this query.')
             return []
-        except ValueError:  # catch simplejson.decoder.JSONDecodeError
-            raise ValueError('API response not valid. JSON decoding failed.')
+        except ValueError:
+            raise SentinelAPIError(http_status=self.content.status_code,
+                                   msg='API response not valid. JSON decoding failed.',
+                                   response_body=self.content.content)
 
     def get_products_size(self):
         """Return the total filesize in GB of all products in the query"""
@@ -189,7 +209,7 @@ class SentinelAPI(object):
                 x
                 for x in scene["str"]
                 if x["name"] == "footprint"
-                )["content"][10:-2].split(",")
+            )["content"][10:-2].split(",")
             coord_list_split = (coord.split(" ") for coord in coord_list)
             poly = geojson.Polygon([[
                 tuple((float(coord[0]), float(coord[1])))
@@ -205,24 +225,24 @@ class SentinelAPI(object):
                     x
                     for x in scene["date"]
                     if x["name"] == "beginposition"
-                    )["content"],
+                )["content"],
                 "download_link": next(
                     x
                     for x in scene["link"]
                     if len(x.keys()) == 1
-                    )["href"]
+                )["href"]
             }
             # Sentinel-2 has no "polarisationmode" property
             try:
                 str_properties = ["platformname", "identifier", "polarisationmode",
-                    "sensoroperationalmode", "orbitdirection", "producttype"]
+                                  "sensoroperationalmode", "orbitdirection", "producttype"]
                 for str_prop in str_properties:
                     props.update(
                         {str_prop: next(x for x in scene["str"] if x["name"] == str_prop)["content"]}
                     )
             except:
                 str_properties = ["platformname", "identifier",
-                    "sensoroperationalmode", "orbitdirection", "producttype"]
+                                  "sensoroperationalmode", "orbitdirection", "producttype"]
                 for str_prop in str_properties:
                     props.update(
                         {str_prop: next(x for x in scene["str"] if x["name"] == str_prop)["content"]}
@@ -255,7 +275,7 @@ class SentinelAPI(object):
             .findtext('{http://www.opengis.net/gml}coordinates')
         coord_string = ",".join(
             [" ".join(double_coord) for double_coord in [coord.split(",") for coord in poly_coords.split(" ")]]
-            )
+        )
 
         keys = ['id', 'title', 'size', 'md5', 'date', 'footprint', 'url']
         values = [
@@ -340,7 +360,7 @@ class SentinelAPI(object):
         # Check integrity with MD5 checksum
         if checksum is True:
             if not md5_compare(path, product_info['md5']):
-                raise InvalidChecksumError('File corrupt: Checksums do not match')
+                raise InvalidChecksumError('File corrupt: checksums do not match')
         return path, product_info
 
     def download_all(self, directory_path='.', max_attempts=10, checksum=False, check_existing=False, **kwargs):

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -1,15 +1,15 @@
+import hashlib
+import textwrap
+from datetime import date, datetime, timedelta
+from os import environ
+
 import geojson
 import py.path
 import pytest
-import requests
 import requests_mock
 
-from datetime import datetime, date, timedelta
-from os import environ
-import hashlib
-
-from sentinelsat.sentinel import (SentinelAPI, format_date, get_coordinates,
-    convert_timestamp, md5_compare, InvalidChecksumError)
+from sentinelsat.sentinel import (InvalidChecksumError, SentinelAPI, SentinelAPIError, convert_timestamp, format_date,
+                                  get_coordinates, md5_compare)
 
 
 @pytest.mark.fast
@@ -41,12 +41,12 @@ def test_SentinelAPI_connection():
     api = SentinelAPI(
         environ['SENTINEL_USER'],
         environ['SENTINEL_PASSWORD']
-        )
+    )
     api.query('0 0,1 1,0 1,0 0', datetime(2015, 1, 1), datetime(2015, 1, 2))
 
     assert api.url == 'https://scihub.copernicus.eu/apihub/search?format=json&rows=15000'
     assert api.last_query == '(beginPosition:[2015-01-01T00:00:00Z TO 2015-01-02T00:00:00Z]) ' + \
-        'AND (footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))")'
+                             'AND (footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))")'
     assert api.content.status_code == 200
 
 
@@ -55,12 +55,12 @@ def test_SentinelAPI_wrong_credentials():
     api = SentinelAPI(
         "wrong_user",
         "wrong_password"
-        )
-    with pytest.raises(requests.HTTPError):
+    )
+    with pytest.raises(SentinelAPIError) as excinfo:
         api.query('0 0,1 1,0 1,0 0', datetime(2015, 1, 1), datetime(2015, 1, 2))
-    assert api.content.status_code == 401
+    assert excinfo.value.http_status == 401
 
-    with pytest.raises(ValueError):
+    with pytest.raises(SentinelAPIError):
         api.get_products_size()
         api.get_products()
 
@@ -70,20 +70,20 @@ def test_api_query_format():
     api = SentinelAPI(
         environ['SENTINEL_USER'],
         environ['SENTINEL_PASSWORD']
-        )
+    )
 
     now = datetime.now()
     query = api.format_query('0 0,1 1,0 1,0 0', end_date=now)
     last_24h = format_date(now - timedelta(hours=24))
     assert api.url == 'https://scihub.copernicus.eu/apihub/search?format=json&rows=15000'
     assert query == '(beginPosition:[%s TO %s]) ' % (last_24h, format_date(now)) + \
-        'AND (footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))")'
+                    'AND (footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))")'
 
     query = api.format_query('0 0,1 1,0 1,0 0', end_date=now, producttype='SLC')
     assert api.url == 'https://scihub.copernicus.eu/apihub/search?format=json&rows=15000'
     assert query == '(beginPosition:[%s TO %s]) ' % (last_24h, format_date(now)) + \
-        'AND (footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))") ' + \
-        'AND (producttype:SLC)'
+                    'AND (footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))") ' + \
+                    'AND (producttype:SLC)'
 
 
 @pytest.mark.scihub
@@ -91,9 +91,11 @@ def test_invalid_query():
     api = SentinelAPI(
         environ['SENTINEL_USER'],
         environ['SENTINEL_PASSWORD']
-        )
-    with pytest.raises(requests.HTTPError):
+    )
+    with pytest.raises(SentinelAPIError) as excinfo:
         api.query_raw("xxx:yyy")
+    assert excinfo.value.msg is not None
+    print(excinfo)
 
 
 @pytest.mark.scihub
@@ -102,12 +104,12 @@ def test_set_base_url():
         environ['SENTINEL_USER'],
         environ['SENTINEL_PASSWORD'],
         'https://scihub.copernicus.eu/dhus/'
-        )
+    )
     api.query('0 0,1 1,0 1,0 0', datetime(2015, 1, 1), datetime(2015, 1, 2))
 
     assert api.url == 'https://scihub.copernicus.eu/dhus/search?format=json&rows=15000'
     assert api.last_query == '(beginPosition:[2015-01-01T00:00:00Z TO 2015-01-02T00:00:00Z]) ' + \
-        'AND (footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))")'
+                             'AND (footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))")'
     assert api.content.status_code == 200
 
 
@@ -116,7 +118,7 @@ def test_trail_slash_base_url():
     base_urls = [
         'https://scihub.copernicus.eu/dhus/',
         'https://scihub.copernicus.eu/dhus'
-        ]
+    ]
 
     expected = 'https://scihub.copernicus.eu/dhus/'
 
@@ -126,7 +128,7 @@ def test_trail_slash_base_url():
             environ['SENTINEL_USER'],
             environ['SENTINEL_PASSWORD'],
             test_url
-            )
+        )
         assert api.api_url == expected
 
 
@@ -142,7 +144,7 @@ def test_get_product_info():
     api = SentinelAPI(
         environ['SENTINEL_USER'],
         environ['SENTINEL_PASSWORD']
-        )
+    )
 
     expected_s1 = {
         'id': '8df46c9e-a20c-43db-a19a-4240c2ed3b8b',
@@ -153,7 +155,7 @@ def test_get_product_info():
         'footprint': '-5.880887 -63.852531,-5.075419 -67.495872,-3.084356 -67.066071,-3.880541 -63.430576,'
                      '-5.880887 -63.852531',
         'title': 'S1A_EW_GRDM_1SDV_20151121T100356_20151121T100429_008701_00C622_A0EC'
-        }
+    }
 
     expected_s2 = {
         'date': '2015-12-27T14:22:29Z',
@@ -188,26 +190,63 @@ def test_get_product_info_scihub_down():
         rqst.get(
             "https://scihub.copernicus.eu/apihub/odata/v1/Products('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')/?$format=json",
             text="Mock SciHub is Down", status_code=503
-            )
-        with pytest.raises(requests.HTTPError) as val_err:
+        )
+        with pytest.raises(SentinelAPIError) as excinfo:
             api.get_product_info('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')
 
         rqst.get(
             "https://scihub.copernicus.eu/apihub/odata/v1/Products('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')/?$format=json",
             text='{"error":{"code":null,"message":{"lang":"en","value":'
                  '"No Products found with key \'8df46c9e-a20c-43db-a19a-4240c2ed3b8b\' "}}}', status_code=500
-            )
-        with pytest.raises(ValueError) as val_err:
+        )
+        with pytest.raises(SentinelAPIError) as excinfo:
             api.get_product_info('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')
-            assert val_err.value.message == "No Products found with key \'8df46c9e-a20c-43db-a19a-4240c2ed3b8b\' "
+        assert excinfo.value.msg == "No Products found with key \'8df46c9e-a20c-43db-a19a-4240c2ed3b8b\' "
 
         rqst.get(
             "https://scihub.copernicus.eu/apihub/odata/v1/Products('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')/?$format=json",
             text="Mock SciHub is Down", status_code=200
-            )
-        with pytest.raises(ValueError) as val_err:
+        )
+        with pytest.raises(SentinelAPIError) as excinfo:
             api.get_product_info('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')
-            assert val_err.value.message == "Invalid API response. JSON decoding failed."
+        assert excinfo.value.msg == "Mock SciHub is Down"
+
+        # Test with a real server response
+        rqst.get(
+            "https://scihub.copernicus.eu/apihub/odata/v1/Products('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')/?$format=json",
+            text=textwrap.dedent("""\
+            <!doctype html>
+            <title>The Sentinels Scientific Data Hub</title>
+            <link href='https://fonts.googleapis.com/css?family=Open+Sans' rel='stylesheet' type='text/css'>
+            <style>
+            body { text-align: center; padding: 125px; background: #fff;}
+            h1 { font-size: 50px; }
+            body { font: 20px 'Open Sans',Helvetica, sans-serif; color: #333; }
+            article { display: block; text-align: left; width: 820px; margin: 0 auto; }
+            a { color: #0062a4; text-decoration: none; font-size: 26px }
+            a:hover { color: #1b99da; text-decoration: none; }
+            </style>
+
+            <article>
+            <img alt="" src="/datahub.png" style="float: left;margin: 20px;">
+            <h1>The Sentinels Scientific Data Hub will be back soon!</h1>
+            <div style="margin-left: 145px;">
+            <p>
+            Sorry for the inconvenience,<br/>
+            we're performing some maintenance at the moment.<br/>
+            </p>
+            <!--<p><a href="https://scihub.copernicus.eu/news/News00098">https://scihub.copernicus.eu/news/News00098</a></p>-->
+            <p>
+            We'll be back online shortly!
+            </p>
+            </div>
+            </article>
+            """),
+            status_code=502)
+        with pytest.raises(SentinelAPIError) as excinfo:
+            api.get_product_info('8df46c9e-a20c-43db-a19a-4240c2ed3b8b')
+        print(excinfo.value)
+        assert "The Sentinels Scientific Data Hub will be back soon!" in excinfo.value.msg
 
 
 @pytest.mark.mock_api
@@ -216,17 +255,17 @@ def test_get_products_invalid_json():
     with requests_mock.mock() as rqst:
         rqst.post(
             'https://scihub.copernicus.eu/apihub/search?format=json&rows=15000',
-            text="Invalid JSON response", status_code=200
-            )
-        api.query(
-            area=get_coordinates("tests/map.geojson"),
-            initial_date="20151219",
-            end_date="20151228",
-            platformname="Sentinel-2"
+            text="{Invalid JSON response", status_code=200
         )
-        with pytest.raises(ValueError) as val_err:
+        with pytest.raises(SentinelAPIError) as excinfo:
+            api.query(
+                area=get_coordinates("tests/map.geojson"),
+                initial_date="20151219",
+                end_date="20151228",
+                platformname="Sentinel-2"
+            )
             api.get_products()
-            assert val_err.value.message == "API response not valid. JSON decoding failed."
+        assert excinfo.value.msg == "API response not valid. JSON decoding failed."
 
 
 @pytest.mark.scihub
@@ -234,11 +273,11 @@ def test_footprints_s1():
     api = SentinelAPI(
         environ['SENTINEL_USER'],
         environ['SENTINEL_PASSWORD']
-        )
+    )
     api.query(
         get_coordinates('tests/map.geojson'),
         datetime(2014, 10, 10), datetime(2014, 12, 31), producttype="GRD"
-        )
+    )
 
     with open('tests/expected_search_footprints_s1.geojson', 'r') as geojson_file:
         expected_footprints = geojson.loads(geojson_file.read())
@@ -251,11 +290,11 @@ def test_footprints_s2():
     api = SentinelAPI(
         environ['SENTINEL_USER'],
         environ['SENTINEL_PASSWORD']
-        )
+    )
     api.query(
         get_coordinates('tests/map.geojson'),
         "20151219", "20151228", platformname="Sentinel-2"
-        )
+    )
 
     with open('tests/expected_search_footprints_s2.geojson', 'r') as geojson_file:
         expected_footprints = geojson.loads(geojson_file.read())
@@ -268,13 +307,13 @@ def test_s2_cloudcover():
     api = SentinelAPI(
         environ['SENTINEL_USER'],
         environ['SENTINEL_PASSWORD']
-        )
+    )
     api.query(
         get_coordinates('tests/map.geojson'),
         "20151219", "20151228",
         platformname="Sentinel-2",
         cloudcoverpercentage="[0 TO 10]"
-        )
+    )
     assert len(api.get_products()) == 3
     assert api.get_products()[0]["id"] == "6ed0b7de-3435-43df-98bf-ad63c8d077ef"
     assert api.get_products()[1]["id"] == "37ecee60-23d8-4ec2-a65f-2de24f51d30e"
@@ -286,11 +325,11 @@ def test_get_products_size():
     api = SentinelAPI(
         environ['SENTINEL_USER'],
         environ['SENTINEL_PASSWORD']
-        )
+    )
     api.query(
         get_coordinates('tests/map.geojson'),
         "20151219", "20151228", platformname="Sentinel-2"
-        )
+    )
     assert api.get_products_size() == 63.58
 
     api.query_raw("S1A_WV_OCN__2SSH_20150603T092625_20150603T093332_006207_008194_521E")


### PR DESCRIPTION
The code currently raises `ValueError`s and `HTTPError`s for server-side problems. I merged both cases into single `SentinelAPIError` that provides the following attributes:
* `http_status`,
* `code`,
* `msg`,
* `response_body`.

Any non-JSON reponses will be converted from HTML to plain text (with markdown).

All tests pass for Python 2.7 and 3.5.

Feel free to change anything or ask me for additional modifications, if necessary.