### PR TITLE
Use a workaround only for older versions of PycURL

### DIFF
--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -8,7 +8,7 @@ import xml.etree.ElementTree as ET
 from datetime import datetime, date, timedelta
 from os import remove
 from os.path import join, exists, getsize
-from pycurl import CAINFO
+import pycurl
 from time import sleep
 
 import geojson
@@ -330,7 +330,8 @@ class SentinelAPI(object):
                 print('%s was already downloaded but is corrupt: checksums do not match. Re-downloading.' % path)
                 remove(path)
 
-        if exists(path) and getsize(path) >= 2 ** 31:
+        if (exists(path) and getsize(path) >= 2 ** 31 and
+            pycurl.version.split()[0].lower() <= 'pycurl/7.43.0'):
             # Workaround for PycURL's bug when continuing > 2 GB files
             # https://github.com/pycurl/pycurl/issues/405
             remove(path)
@@ -404,7 +405,7 @@ class SentinelAPI(object):
         as established at libcurl build time.
         """
         try:
-            cainfo = kwargs_dict['pass_through_opts'][CAINFO]
+            cainfo = kwargs_dict['pass_through_opts'][pycurl.CAINFO]
         except KeyError:
             try:
                 cainfo = certifi.where()
@@ -413,7 +414,7 @@ class SentinelAPI(object):
 
         if cainfo is not None:
             pass_through_opts = kwargs_dict.get('pass_through_opts', {})
-            pass_through_opts[CAINFO] = cainfo
+            pass_through_opts[pycurl.CAINFO] = cainfo
             kwargs_dict['pass_through_opts'] = pass_through_opts
 
         return kwargs_dict


### PR DESCRIPTION
The issue https://github.com/pycurl/pycurl/issues/405 has been fixed but is awaiting a release, after which the workaround used in sentinelsat should be ignored.