### PR TITLE
Missing RTD requirements

### DIFF
--- a/docs/readthedocs-requirements.txt
+++ b/docs/readthedocs-requirements.txt
@@ -2,3 +2,4 @@ requests
 click
 geojson
 numpydoc
+html2text

--- a/docs/readthedocs-requirements.txt
+++ b/docs/readthedocs-requirements.txt
@@ -3,3 +3,4 @@ click
 geojson
 numpydoc
 html2text
+tqdm


### PR DESCRIPTION
Some modules have been missing from the ReadTheDocs requirements (html2text, tqdm). This causes the build to succeed but the API documentation stays empty.