### PR TITLE
changed RTD requirements

### DIFF
--- a/docs/readthedocs-requirements.txt
+++ b/docs/readthedocs-requirements.txt
@@ -1,6 +1,2 @@
-requests
-click
-geojson
 numpydoc
-html2text
-tqdm
+-r ../requirements.txt


### PR DESCRIPTION
The ReadTheDocs requirements file now recursively includes the standard requirements file (as suggested by @valgur in #55).

Now we have a unified place for the requirements. Should we include new C extensions they still need to be mocked in `docs/conf.py` for RTD builds to work.