### PR TITLE
remove _url_trail_slash

### DIFF
--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -122,7 +122,7 @@ class SentinelAPI(object):
     def __init__(self, user, password, api_url='https://scihub.copernicus.eu/apihub/'):
         self.session = requests.Session()
         self.session.auth = (user, password)
-        self.api_url = self._url_trail_slash(api_url)
+        self.api_url = api_url
         self.last_query = None
         self.content = None
         self.products = None
@@ -145,13 +145,6 @@ class SentinelAPI(object):
         self.last_query = query
         self.content = requests.post(self.url, dict(q=query), auth=self.session.auth)
         _check_scihub_response(self.content)
-
-    @staticmethod
-    def _url_trail_slash(api_url):
-        """Add trailing slash to the api url if it is missing"""
-        if api_url[-1] is not '/':
-            api_url += '/'
-        return api_url
 
     @staticmethod
     def format_query(area, initial_date=None, end_date=datetime.now(), **keywords):

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -111,23 +111,6 @@ def test_set_base_url():
 
 
 @pytest.mark.fast
-def test_trail_slash_base_url():
-    base_urls = [
-        'https://scihub.copernicus.eu/dhus/',
-        'https://scihub.copernicus.eu/dhus'
-    ]
-
-    expected = 'https://scihub.copernicus.eu/dhus/'
-
-    for test_url in base_urls:
-        assert SentinelAPI._url_trail_slash(test_url) == expected
-        api = SentinelAPI("mock_user", "mock_password",
-            test_url
-        )
-        assert api.api_url == expected
-
-
-@pytest.mark.fast
 def test_get_coordinates():
     coords = ('-66.2695312 -8.0592296,-66.2695312 0.7031074,' +
               '-57.3046875 0.7031074,-57.3046875 -8.0592296,-66.2695312 -8.0592296')


### PR DESCRIPTION
`_url_trail_slash` is broken as discussed in https://github.com/ibamacsr/sentinelsat/issues/52#issuecomment-256567082 .

But as far as I can see, we do not need to take care whether the URL has a trailing slash or not, since we use `urljoin` for all subsequent URL manipulations.

So this PR removes `_url_trail_slash` entirely. 