### PR TITLE
Limit rows and query in multiple iterations

### DIFF
--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -124,6 +124,7 @@ class SentinelAPI(object):
         self.session.auth = (user, password)
         self.api_url = api_url
         self.last_query = None
+        self.last_status_code = None
         self.content = None
         self.products = []
         self.max_rows = max_rows
@@ -138,7 +139,6 @@ class SentinelAPI(object):
         and any other search keywords accepted by the SciHub API.
         """
         query = self.format_query(area, initial_date, end_date, **keywords)
-        self.last_query = query
         self.load_query(query)
         return self.products
 
@@ -146,12 +146,18 @@ class SentinelAPI(object):
         """Do a full-text query on the SciHub API using the format specified in
            https://scihub.copernicus.eu/twiki/do/view/SciHubUserGuide/3FullTextSearch
         """
+        # store last query (for testing)
+        self.last_query = query
+
         # generate URL
         url = self.format_url(start_row=start_row)
 
         # load query results
         content = requests.post(url, dict(q=query), auth=self.session.auth)
         _check_scihub_response(content)
+
+        # store last status code (for testing)
+        self.last_status_code = content.status_code
 
         # parse content
         total_results = 0

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -123,6 +123,7 @@ class SentinelAPI(object):
         self.session = requests.Session()
         self.session.auth = (user, password)
         self.api_url = api_url
+        self.url = None
         self.last_query = None
         self.last_status_code = None
         self.content = None

--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -122,7 +122,7 @@ class SentinelAPI(object):
     def __init__(self, user, password, api_url='https://scihub.copernicus.eu/apihub/'):
         self.session = requests.Session()
         self.session.auth = (user, password)
-        self.api_url = self._url_trail_slash(api_url)
+        self.api_url = api_url
         self.last_query = None
         self.content = None
         self.products = None
@@ -145,13 +145,6 @@ class SentinelAPI(object):
         self.last_query = query
         self.content = requests.post(self.url, dict(q=query), auth=self.session.auth)
         _check_scihub_response(self.content)
-
-    @staticmethod
-    def _url_trail_slash(api_url):
-        """Add trailing slash to the api url if it is missing"""
-        if api_url[-1] is not '/':
-            api_url += '/'
-        return api_url
 
     @staticmethod
     def format_query(area, initial_date=None, end_date=datetime.now(), **keywords):

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -111,23 +111,6 @@ def test_set_base_url():
 
 
 @pytest.mark.fast
-def test_trail_slash_base_url():
-    base_urls = [
-        'https://scihub.copernicus.eu/dhus/',
-        'https://scihub.copernicus.eu/dhus'
-    ]
-
-    expected = 'https://scihub.copernicus.eu/dhus/'
-
-    for test_url in base_urls:
-        assert SentinelAPI._url_trail_slash(test_url) == expected
-        api = SentinelAPI("mock_user", "mock_password",
-            test_url
-        )
-        assert api.api_url == expected
-
-
-@pytest.mark.fast
 def test_get_coordinates():
     coords = ('-66.2695312 -8.0592296,-66.2695312 0.7031074,' +
               '-57.3046875 0.7031074,-57.3046875 -8.0592296,-66.2695312 -8.0592296')

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -22,8 +22,8 @@ _large_query = dict(
         end_date=datetime(2015, 12, 31))
 
 _api_auth = dict(
-        user=environ['SENTINEL_USER'],
-        password=environ['SENTINEL_PASSWORD'])
+        user=environ.get('SENTINEL_USER'),
+        password=environ.get('SENTINEL_PASSWORD'))
 
 _api_kwargs = dict(_api_auth,
         api_url='https://scihub.copernicus.eu/apihub/')

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -72,12 +72,10 @@ def test_api_query_format():
     now = datetime.now()
     query = api.format_query('0 0,1 1,0 1,0 0', end_date=now)
     last_24h = format_date(now - timedelta(hours=24))
-    assert api.url == 'https://scihub.copernicus.eu/apihub/search?format=json&rows=15000'
     assert query == '(beginPosition:[%s TO %s]) ' % (last_24h, format_date(now)) + \
                     'AND (footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))")'
 
     query = api.format_query('0 0,1 1,0 1,0 0', end_date=now, producttype='SLC')
-    assert api.url == 'https://scihub.copernicus.eu/apihub/search?format=json&rows=15000'
     assert query == '(beginPosition:[%s TO %s]) ' % (last_24h, format_date(now)) + \
                     'AND (footprint:"Intersects(POLYGON((0 0,1 1,0 1,0 0)))") ' + \
                     'AND (producttype:SLC)'


### PR DESCRIPTION
This PR addresses issue #57.

The solution required some restructuring of the api methods:

1. A new method `load_query` combines both, the execution of a query against the OpenSearch API (formerly done in `query_raw`, which was removed) and the parsing and evaluation of the JSON response (formerly done in `get_products`).

1. The attribute `url` is now an actual attribute, set by a new function, `format_url`, which generates the SciHub url with a `start` parameter (the starting row for paging).

1. The `products` attribute is now a list from the beginning (`init`) that gets extended by every call to `query` or `load_query`. This change is not strictly necessary (`products` could also be reset for every `query` call), but one I find logical: You can execute several queries and the api instance will store the products, e.g. for a single subsequent call to `download_all`.

None of these changes affect the CLI and for users who just used the `query` method, nothing changed.

The tests are changed accordingly and I added one for a large query that returns over 100 products to show that it works.

NB: Some credit for this code goes to @radosuav.