### PR TITLE
Logging

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -32,6 +32,37 @@ Valid search query keywords can be found at the `ESA SciHub documentation
 <https://scihub.copernicus.eu/userguide/3FullTextSearch>`_.
 
 
+Logging
+-------
+
+Sentinelsat logs to ``sentinelsat`` and the API to ``sentinelsat.SentinelAPI``.
+
+There is no predefined `logging<https://docs.python.org/3/library/logging.html>`_ handler, 
+so in order to have your script print the log messages, either use ``logging.baseConfig``
+
+.. code-block:: python
+
+  import logging
+
+  logging.basicConfig(format='%(message)s', level='INFO')
+
+
+or add a custom handler for ``sentinelsat``
+
+.. code-block:: python
+
+  import logging
+
+  logger = logging.getLogger('sentinelsat')
+  logger.setLevel('INFO')
+
+  h = logging.StreamHandler()
+  h.setLevel('INFO')
+  fmt = logging.Formatter('%(message)s')
+  h.setFormatter(fmt)
+  logger.addHandler(h)
+
+
 API
 -----------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -47,7 +47,7 @@ so in order to have your script print the log messages, either use ``logging.bas
   logging.basicConfig(format='%(message)s', level='INFO')
 
 
-or add a custom handler for ``sentinelsat``
+or add a custom handler for ``sentinelsat`` (as implemented in ``cli.py``)
 
 .. code-block:: python
 

--- a/sentinelsat/scripts/cli.py
+++ b/sentinelsat/scripts/cli.py
@@ -1,14 +1,26 @@
 import click
 import geojson as gj
+import logging
 
 import os
 
 from sentinelsat.sentinel import SentinelAPI, get_coordinates
 
+logger = logging.getLogger('sentinelsat')
+
+
+def _set_logger_handler(level='INFO'):
+    logger.setLevel(level)
+    h = logging.StreamHandler()
+    h.setLevel(level)
+    fmt = logging.Formatter('%(message)s')
+    h.setFormatter(fmt)
+    logger.addHandler(h)
+
 
 @click.group()
 def cli():
-    pass
+    _set_logger_handler()
 
 
 @cli.command()
@@ -97,9 +109,9 @@ def search(
                         outfile.write("%s : %s\n" % corrupt_tuple)
     else:
         for product in products:
-            print('Product %s - %s' % (product['id'], product['summary']))
-        print('---')
-        print(
+            logger.info('Product %s - %s' % (product['id'], product['summary']))
+        logger.info('---')
+        logger.info(
             '%s scenes found with a total size of %.2f GB' %
             (len(products), api.get_products_size(products)))
 


### PR DESCRIPTION
This is one of the many ways to implement logging (#83): SentinelAPI gets a `logger` attribute (logger name `sentinelsat.SentinelAPI`) and logs to that. The CLI also uses logging and sets a simple `StreamHandler` (logger name `sentinelsat`) that captures both, the messages from SentinelAPI and its own.

For the CLI, we could also use https://github.com/click-contrib/click-log, but that would add another dependency and not that much value (color messages).

The module does not add any handlers, following http://docs.python-guide.org/en/latest/writing/logging/
> It is strongly advised that you do not add any handlers other than NullHandler to your library’s loggers.
except when called through CLI.

Please let me know if you want something changed.