### PR TITLE
Add function to download_all pandas

### DIFF
--- a/sentinelsat/sentinel.py
+++ b/sentinelsat/sentinel.py
@@ -215,6 +215,14 @@ class SentinelAPI(object):
         df.drop(['footprint', 'gmlfootprint'], axis=1, inplace=True)
         return gpd.GeoDataFrame(df, crs=crs, geometry=geometry)
 
+    @staticmethod
+    def dataframe_to_products_list(products_df):
+        """Convert dataframe created with to_dataframe back to list of products for download_all"""
+        products = []
+        for title, row in products_df.iterrows():
+            products.append(dict(title=title, id=row['id']))
+        return products
+
     def get_product_odata(self, id):
         """Access SciHub OData API to get info about a Product. Returns a dict
         containing the id, title, size, md5sum, date, footprint and download url
@@ -328,7 +336,7 @@ class SentinelAPI(object):
 
     def download_all(self, products, directory_path='.', max_attempts=10, checksum=False, check_existing=False,
                      **kwargs):
-        """Download all products returned in query().
+        """Download a list of products
 
         File names on the server are used for the downloaded files, e.g.
         "S1A_EW_GRDH_1SDH_20141003T003840_20141003T003920_002658_002F54_4DD1.zip".
@@ -338,8 +346,8 @@ class SentinelAPI(object):
 
         Parameters
         ----------
-        products : list
-            List of products returned with self.query()
+        products : list of dict
+            List of products dicts with keys 'title' and 'id'
         directory_path : string
             Directory where the downloaded files will be downloaded
         max_attempts : int, optional

--- a/tests/test_mod.py
+++ b/tests/test_mod.py
@@ -396,6 +396,23 @@ def test_to_geopandas():
     gdf = api.to_geodataframe(products)
 
 
+@my_vcr.use_cassette('test_to_dict')
+@pytest.mark.pandas
+@pytest.mark.geopandas
+@pytest.mark.scihub
+def test_pandas_to_products_list():
+    api = SentinelAPI(**_api_auth)
+    products = api.query(
+        get_coordinates('tests/map.geojson'),
+        "20151219", "20151228", platformname="Sentinel-2"
+    )
+    df = api.to_dataframe(products)
+    products_conv = api.dataframe_to_products_list(df)
+    title_id_conv = set([(d['title'], d['id']) for d in products_conv])
+    title_id_orig = set([(d['title'], d['id']) for d in products])
+    assert title_id_conv == title_id_orig
+
+
 @pytest.mark.homura
 @pytest.mark.scihub
 def test_download(tmpdir):


### PR DESCRIPTION
So we have a nice `to_dataframe` function since https://github.com/ibamacsr/sentinelsat/pull/97.

But once you used the dataframe to filter or group the products returned by the query, how do you **download** them?

You could loop through their IDs with `api.download`. But wouldn't it be more convenient to be able to somehow pass that dataframe to `download_all`?

It turns out all `download_all` needs from the product dict are `id` and `title`. So here is a function that converts a dataframe to a list of dictionaries with these keys.

Now you decide @willemarcel if this is going too far with `@staticmethods` popping up everywhere... I think this is a logical addition to the `to_dataframe` and `to_geodataframe` methods.