### PR TITLE
Cleaner exception messages

### DIFF
--- a/tests/vcr_cassettes/test_get_product_info_bad_key.yaml
+++ b/tests/vcr_cassettes/test_get_product_info_bad_key.yaml
@@ -1,0 +1,23 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [sentinelsat/0.9.1]
+    method: GET
+    uri: https://scihub.copernicus.eu/apihub/odata/v1/Products('invalid-xyz')/?$format=json
+  response:
+    body: {string: '{"error":{"code":null,"message":{"lang":"en","value":"Invalid
+        key (invalid-xyz) to access Products"}}}'}
+    headers:
+      Content-Length: ['102']
+      Content-Type: [application/json]
+      DataServiceVersion: ['1.0']
+      Date: ['Sun, 09 Apr 2017 22:44:50 GMT']
+      Pragma: [no-cache]
+      Server: [Apache-Coyote/1.1]
+      cause-message: ['InvalidKeyException : Invalid key (invalid-xyz) to access Products']
+    status: {code: 500, message: Internal Server Error}
+version: 1


### PR DESCRIPTION
I noticed that the server responses for errors include `cause-message` headers such as
```
cause-message: 'IOException : Server returned HTTP response code: 400 for URL:
          http://localhost:30333//solr/dhus/select?q=xxx:yyy&wt=xslt&tr=opensearch_atom.xsl&dhusLongName=Sentinels+Scientific+Data+Hub&dhusServer=https%3A%2F%2Fscihub.copernicus.eu%2Fapihub%2F&originalQuery=xxx%3Ayyy&rows=100&start=0&sort=ingestiondate+desc'
```
This provides essentially the same information but in a lot more concise and less intimidating manner than the wall-of-text stacktraces (such as in #67) have so far, so I modified the SentinelAPIError to use that instead.